### PR TITLE
v0.9.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _*
 .old*
 vendor/*
+dist/*

--- a/bin/abuseipdb
+++ b/bin/abuseipdb
@@ -14,54 +14,48 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 
 use Kristuff\AbuseIPDB\AbuseIPDBClient;
 
 /**
- * Autoloading (depending on install directory) 
+ * Autoloading and locate config (depending on install directory) 
  * 
- * 1/ Installed with create-project abuseipdb-client
+ * 1/ Project installed with git clone or create-project abuseipdb-cli:
+ *    bin and config folder at same level 
  * 
- *  project
- *    |_ bin
- *       xxx symlink
- *    |_ config
- *    |_ vendor
- *         |_ kristuff
- *               |_  abusedipdb-cli
- *                       |_ bin 
- *                            xxx <- me
- * 
- * 2/ installed with git clone or create-project abuseipdb-cli
- *    bin and config folder as same level 
- * 
- *   project
- *      |_ bin 
+ *   ~/abuseipdb-cli/
+ *      |_ bin/ 
  *           xxx <- me
- *      |_ config
- *      |_ vendor
+ *      |_ config/
+ *      |_ vendor/
+ * 
+ * 2/ In case the .deb package is installed, config folder
+ *    is located in /etc/abuseipdb-client and main library in
+ *    /usr/lib/abuseipdb-client 
+ * 
+ *   /usr/lib/abuseipdb-client/
+ *      |_ bin/ 
+ *           xxx <- me
+ *      |_ vendor/
+ 
+ *   /etc/abuseipdb-client/
+ *      conf...
  * 
 */
 
-//  2/ git clone or create-project abuseipdb-cli
+//  1/ git clone or create-project abuseipdb-cli
 $autoloadPath   = realpath(__DIR__) .'/../vendor/autoload.php';
-$keyPath        = realpath(__DIR__) .'/../config/key.json';
+$configPath     = realpath(__DIR__) .'/../config';
 
-//  test for 1/
-$parentDirectory    = dirname(get_included_files()[0], 2);
-$subParentDirectory = dirname(get_included_files()[0], 3);
-$vendorDirectory    = dirname(get_included_files()[0], 4); // should be vendor
+//  test for 2/
+$globalConfPath = '/etc/abuseipdb-client'; 
+if (file_exists($globalConfPath) && is_dir($globalConfPath)){
+    $configPath = $globalConfPath;
+}
 
-if (pathinfo($parentDirectory, PATHINFO_BASENAME) === 'abuseipdb-cli' && 
-    pathinfo($subParentDirectory, PATHINFO_BASENAME) === 'kristuff' && 
-    pathinfo($vendorDirectory, PATHINFO_BASENAME) === 'vendor') {
-
-    $keyPath       = $vendorDirectory . '/../config/key.json';
-    $autoloadPath  = $vendorDirectory .'/autoload.php';
-};
 
 require_once $autoloadPath;
 
@@ -70,7 +64,7 @@ AbuseIPDBClient::start(
         AbuseIPDBClient::SHORT_ARGUMENTS,
         AbuseIPDBClient::LONG_ARGUMENTS
     ), 
-    $keyPath
+    $configPath
 );
 
 ?>

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,113 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "42c454b4daa1ae6cea621e49a81423fe",
+    "packages": [
+        {
+            "name": "kristuff/abuseipdb",
+            "version": "v0.9.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kristuff/abuseipdb.git",
+                "reference": "3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kristuff/abuseipdb/zipball/3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8",
+                "reference": "3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kristuff\\AbuseIPDB\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kristuff",
+                    "email": "kristuff@kristuff.fr",
+                    "homepage": "https://github.com/kristuff",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP wrapper for AbuseIPDB API v2",
+            "keywords": [
+                "abuseipdb",
+                "api"
+            ],
+            "support": {
+                "issues": "https://github.com/kristuff/abuseipdb/issues",
+                "source": "https://github.com/kristuff/abuseipdb/tree/v0.9.13"
+            },
+            "time": "2021-09-18T19:42:24+00:00"
+        },
+        {
+            "name": "kristuff/mishell",
+            "version": "v1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kristuff/mishell.git",
+                "reference": "7c23c174532a9f543ab348528c99c48f09277b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kristuff/mishell/zipball/7c23c174532a9f543ab348528c99c48f09277b62",
+                "reference": "7c23c174532a9f543ab348528c99c48f09277b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kristuff\\Mishell\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "kristuff",
+                    "homepage": "https://github.com/kristuff"
+                }
+            ],
+            "description": "A mini PHP library to build beautiful CLI apps and reports",
+            "homepage": "https://kristuff.fr/projects/mishell",
+            "keywords": [
+                "cli",
+                "color",
+                "table"
+            ],
+            "support": {
+                "issues": "https://github.com/kristuff/mishell/issues",
+                "source": "https://github.com/kristuff/mishell/tree/v1.5"
+            },
+            "time": "2021-01-28T19:01:18+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.1"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/config/conf.ini
+++ b/config/conf.ini
@@ -1,0 +1,33 @@
+;        _                 ___ ___ ___  ___
+;   __ _| |__ _  _ ___ ___|_ _| _ \   \| _ )
+;  / _` | '_ \ || (_-</ -_)| ||  _/ |) | _ \
+;  \__,_|_.__/\_,_/__/\___|___|_| |___/|___/
+;  
+;  Kristuff\AbuseIPDB-client configuration file.
+;  v0.9.15 | (c) Kristuff <kristuff@kristuff.fr>
+
+; -----------------------------------------------------------
+; WARNING:  In most of the cases you should not modify this                    
+;           file, but provide customizations in a local.ini 
+;           file under this directory. In case package is 
+;           installed globally, this prevents to lost changes 
+;           during update.                        
+; -----------------------------------------------------------
+
+
+[common]
+; api_key:
+;   Your api key on abuseipdb.com (mandatory)
+;
+;   Example: 
+;     api_key= "1234"
+api_key= 
+
+[report]
+; self_ips: 
+;   Represents the ips or domain list to exclude from report messages (email address are already removed)
+;   List MUST be comma separated and MAY comtain spaces. Order does matter for subdomains.
+;
+;   Example: 
+;      self_ips= "xx9999.ip-256-256-256.xx ,256.256.256.256, subdomain.example.com,example.com, example"
+self_ips= 

--- a/config/config.json
+++ b/config/config.json
@@ -1,3 +1,0 @@
-{
-    "max_check_reports": 5
-}

--- a/config/key.sample.json
+++ b/config/key.sample.json
@@ -1,3 +1,0 @@
-{
-    "api_key": "YOUR ABUSEIPDB API KEY"
-}

--- a/config/self_ips.sample.json
+++ b/config/self_ips.sample.json
@@ -1,9 +1,0 @@
-{
-    "self_ips": [
-        "xx9999.ip-256-256-256.xx",
-        "256.256.256.256",
-        "subdomain.example.com",
-        "example.com",
-        "example"
-    ]
-}

--- a/create_package.sh
+++ b/create_package.sh
@@ -8,18 +8,16 @@ rm -rf debian
 mkdir -p debian/DEBIAN
 mkdir -p debian/usr/lib/abuseipdb-client
 mkdir -p debian/usr/share/doc/abuseipdb-client
-# it's planned to use text files, instead of json
-# for config and properly place them in /etc 
-# mkdir -p debian/etc/abuseipdb-client
+mkdir -p debian/etc/abuseipdb-client
 
 # populate the debian directory
 cp deb/control           debian/DEBIAN
 cp deb/postinst.sh       debian/DEBIAN/postinst
 cp deb/prerm.sh          debian/DEBIAN/prerm
+cp config/conf.ini       debian/etc/abuseipdb-client
 cp deb/copyright         debian/usr/share/doc/abuseipdb-client
 cp LICENSE               debian/usr/lib/abuseipdb-client
 cp -R bin                debian/usr/lib/abuseipdb-client
-cp -R config             debian/etc/lib/abuseipdb-client
 cp -R src                debian/usr/lib/abuseipdb-client
 cp -R vendor             debian/usr/lib/abuseipdb-client
 

--- a/deb/control
+++ b/deb/control
@@ -1,5 +1,5 @@
 Package: abuseipdb-client
-Version: 0.9.14
+Version: 0.9.15
 Maintainer: kristuff <kristuff@kristuff.fr>
 Architecture: all
 Depends: php, php-curl

--- a/src/AbuseIPDBClient.php
+++ b/src/AbuseIPDBClient.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
@@ -39,54 +39,21 @@ class AbuseIPDBClient extends AbstractClient
      * @access public
      * @static
      * @param array     $arguments
-     * @param string    $keyPath        The key file path
+     * @param string    $keyPath        The configuration path
      * 
      * @return void
      */
-    public static function start(array $arguments, string $keyPath): void
+    public static function start(array $arguments, string $confPath): void
     {
         // required at least one valid argument
-        self::$keyPath = $keyPath; 
         self::validate( !empty($arguments), 'No valid arguments given. Run abuseipdb --help to get help.');
-        if (!self::parseCommand($arguments, $keyPath)) {
+        self::$configPath = $confPath; 
+        if (!self::parseCommand($arguments, $confPath)) {
             self::error('Invalid arguments. Run abuseipdb --help to get help.');
             self::printFooter();
             Program::exit(1);
         }
         Program::exit(0);
-    }
-   
-    /**
-     * Register API key in a config file
-     *  
-     * @access protected
-     * @static
-     * 
-     * @return bool
-     */
-    protected static function registerApiKey($arguments): void
-    {
-        self::printTitle(Console::text('  ► Register API key ', 'darkgray'));
-        
-        $key = self::getArgumentValue($arguments,'S', 'save-key');
-        
-        if (empty($key)){
-            self::error('Null or invalid key argument.');
-            self::printFooter();
-            Program::exit(1);
-        }
-
-        $data = json_encode(['api_key' => $key]);
-        
-        if (@file_put_contents(self::$keyPath, $data, LOCK_EX) === false){
-            self::error('An error occurred when writing config file. Make sure to give the appropriate permissions to the config directory.');
-            self::printFooter();
-            Program::exit(1);
-        }
-        Console::log(Console::text('  ✓ ', 'green') . Console::text('Your config key file has been successfully created.', 'white'));
-        Console::log();   
-        self::printFooter();
-        Program::exit();
     }
  
     /**
@@ -99,8 +66,7 @@ class AbuseIPDBClient extends AbstractClient
      */
     protected static function printHelp(): void
     {
-        self::printBanner();
-
+        Console::log();
         Console::log(' ' . Console::text('SYNOPSIS:', 'white', 'underline')); 
         Console::log(' ' . Console::text('    abuseipdb -C ') . 
                            Console::text('IP', 'yellow') . 
@@ -148,9 +114,6 @@ class AbuseIPDBClient extends AbstractClient
                            Console::text('] [-o ') . 
                            Console::text('FORMAT', 'yellow') . 
                            Console::text(']')); 
-
-        Console::log(' ' . Console::text('    abuseipdb -S ' .
-                           Console::text('KEY', 'yellow')));
 
         Console::log(' ' . Console::text('    abuseipdb -L | -G | -h | --version'));
                            
@@ -221,9 +184,7 @@ class AbuseIPDBClient extends AbstractClient
         Console::log(Console::text('   --version', 'white')); 
         Console::log('       Prints the current version.', 'lightgray');
         Console::log(); 
-        Console::log(Console::text('   -S, --save-key ', 'white') . Console::text('KEY', 'yellow', 'underline')); 
-        Console::log('       Save the given API key in the configuration file. Requires writing permissions on the config directory. ', 'lightgray');
-        Console::log(); 
+        self::printFooter();
     }
 
     /**

--- a/src/BulkReportTrait.php
+++ b/src/BulkReportTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/CheckBlockTrait.php
+++ b/src/CheckBlockTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/CheckTrait.php
+++ b/src/CheckTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/ShellErrorHandler.php
+++ b/src/ShellErrorHandler.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/ShellUtils.php
+++ b/src/ShellUtils.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/UtilsTrait.php
+++ b/src/UtilsTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.14
+ * @version    0.9.15
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;


### PR DESCRIPTION
**Changes**
- **Break change** Configuration is now in `INI` format and located in a `conf.ini` file (with possible override in a `local.ini` file) instead of json files.
- The `save-key` command has been removed.
- When installing the `.deb` package, config is now located in `/etc/abuseipdb-client/`.
- Removing support for deploying this project as a dependency (remove other project *abuseipdb-client*). Use `.deb` package or install/update with composer `composer create-project abuseipdb-cli` (`composer update` won't update main project, dependencies only).
- Formatting