### PR TITLE
v0.9.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ More infos
 ----------
 - [Project website](https://kristuff.fr/projects/abuseipdbcli)
 - [Api documentation](https://kristuff.fr/projects/abuseipdbcli/doc)
-- [Config/Install guide](https://kristuff.fr/projects/abuseipdbcli/technical#configuration)
+- [Install](https://kristuff.fr/projects/abuseipdbcli/technical#install)
+- [Config guide](https://kristuff.fr/projects/abuseipdbcli/technical#configuration)
 - [Fail2ban integration](https://kristuff.fr/projects/abuseipdbcli/technical#fail2ban)
 
 Screenshots

--- a/bin/abuseipdb
+++ b/bin/abuseipdb
@@ -14,7 +14,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.1",
         "kristuff/mishell": "^1.5-stable",
-        "kristuff/abuseipdb": "^0.9.13-stable"
+        "kristuff/abuseipdb": "^0.9.14-stable"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42c454b4daa1ae6cea621e49a81423fe",
+    "content-hash": "b7c747fd2936535a7360589ba62f1b7f",
     "packages": [
         {
             "name": "kristuff/abuseipdb",
-            "version": "v0.9.13",
+            "version": "v0.9.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kristuff/abuseipdb.git",
-                "reference": "3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8"
+                "reference": "d1d9cf9ad0fcac083e4c24aa009850e43e83cf24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kristuff/abuseipdb/zipball/3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8",
-                "reference": "3ab67950a1e7ee1e9b23f9afc45a1f553a79b3c8",
+                "url": "https://api.github.com/repos/kristuff/abuseipdb/zipball/d1d9cf9ad0fcac083e4c24aa009850e43e83cf24",
+                "reference": "d1d9cf9ad0fcac083e4c24aa009850e43e83cf24",
                 "shasum": ""
             },
             "require": {
@@ -48,9 +48,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kristuff/abuseipdb/issues",
-                "source": "https://github.com/kristuff/abuseipdb/tree/v0.9.13"
+                "source": "https://github.com/kristuff/abuseipdb/tree/v0.9.14"
             },
-            "time": "2021-09-18T19:42:24+00:00"
+            "time": "2021-12-06T20:40:39+00:00"
         },
         {
             "name": "kristuff/mishell",

--- a/config/conf.ini
+++ b/config/conf.ini
@@ -4,7 +4,7 @@
 ;  \__,_|_.__/\_,_/__/\___|___|_| |___/|___/
 ;  
 ;  Kristuff\AbuseIPDB-client configuration file.
-;  v0.9.16 | (c) Kristuff <kristuff@kristuff.fr>
+;  v0.9.17 | (c) Kristuff <kristuff@kristuff.fr>
 
 ; -----------------------------------------------------------
 ; WARNING:  In most of the cases you should not modify this                    
@@ -22,6 +22,13 @@
 ;   Example: 
 ;     api_key= "1234"
 api_key= 
+
+; timeout:
+;   The maximum number of milliseconds to allow cURL functions to execute. If libcurl is 
+;   built to use the standard system name resolver, that portion of the connect will still 
+;   use full-second resolution for timeouts with a minimum timeout allowed of one second. 
+;   Default is 0 (no timeout) 
+timeout=0
 
 [report]
 ; self_ips: 

--- a/create_package.sh
+++ b/create_package.sh
@@ -8,6 +8,7 @@ rm -rf debian
 mkdir -p debian/DEBIAN
 mkdir -p debian/usr/lib/abuseipdb-client
 mkdir -p debian/usr/share/doc/abuseipdb-client
+mkdir -p debian/usr/share/man/man1
 mkdir -p debian/etc/abuseipdb-client
 
 # populate the debian directory
@@ -16,10 +17,15 @@ cp deb/postinst.sh       debian/DEBIAN/postinst
 cp deb/prerm.sh          debian/DEBIAN/prerm
 cp config/conf.ini       debian/etc/abuseipdb-client
 cp deb/copyright         debian/usr/share/doc/abuseipdb-client
+cp deb/changelog         debian/usr/share/doc/abuseipdb-client/changelog.Debian
+gzip -9 -n               debian/usr/share/doc/abuseipdb-client/changelog.Debian
 cp LICENSE               debian/usr/lib/abuseipdb-client
 cp -R bin                debian/usr/lib/abuseipdb-client
 cp -R src                debian/usr/lib/abuseipdb-client
 cp -R vendor             debian/usr/lib/abuseipdb-client
+
+# convert and deploy man page
+/usr/bin/pandoc --standalone --to man deb/man.md -o debian/usr/share/man/man1/abuseipdb.1
 
 # Packages should't be updated manually, but keep all source code..
 cp composer.json        debian/usr/lib/abuseipdb-client

--- a/deb/changelog
+++ b/deb/changelog
@@ -1,0 +1,30 @@
+abuseipdb-client (0.9.17) unstable; urgency=low
+
+  * New feature: timeout for all cURL request can be defined in conf.ini
+    or from command line using the -t | --timeout option. Timeout is expressed
+    in milliseconds.
+  * A man page is now available  
+
+ -- kristuff <kristuff@kristuff.fr>  Tue, 07 Dec 2021 19:00:00 +0100
+
+abuseipdb-client (0.9.16) unstable; urgency=low
+
+  * Fix php doc, typo, formatting in source code
+  * Include composer.json and composer.lock in .deb package
+
+ -- kristuff <kristuff@kristuff.fr>  Sun, 28 Nov 2021 19:00:00 +0100
+
+ abuseipdb-client (0.9.15) unstable; urgency=low
+
+  * Break change Configuration is now in INI format and located in a conf.ini file 
+    (with possible override in a local.ini file) instead of json files. 
+  * The save-key command has been removed.
+  * When installing the .deb package, config is now located in /etc/abuseipdb-client/
+
+ -- kristuff <kristuff@kristuff.fr>  Tue, 23 Nov 2021 19:00:00 +0100
+
+ abuseipdb-client (0.9.14) unstable; urgency=low
+
+  * Initial release
+
+ -- kristuff <kristuff@kristuff.fr>  Wed, 10 Nov 2021 19:00:00 +0100

--- a/deb/control
+++ b/deb/control
@@ -1,8 +1,8 @@
 Package: abuseipdb-client
-Version: 0.9.16
+Version: 0.9.17
 Maintainer: kristuff <kristuff@kristuff.fr>
 Architecture: all
 Depends: php, php-curl
-Description: CLI tool to check, report IP address, download blacklists with AbuseIPDB API v2
+Description: AbuseIPDB APIv2 client: check, report IP address, download blacklist
 Priority: optional
 Section: utils

--- a/deb/man.md
+++ b/deb/man.md
@@ -1,0 +1,98 @@
+% ABUSEIPDB(1) Abuseipdb Client User Manuals
+% Kristuff 
+% December 7, 2021
+
+# NAME
+
+abuseipdb - check, report IP addresses download blacklist with AbuseIPDB API v2.
+
+# SYNOPSIS
+
+abuseipdb COMMANDE [*OPTIONS*]...
+
+# DESCRIPTION
+
+**abuseipdb** is a client for AbuseIPDB API v2. You can use it to check IP addresses or subnet, 
+report IP addressess, clear your report for a given IP, or download blacklist. 
+
+# COMMANDES
+
+-h, \--help
+:   Displays a short-help text and exits.
+
+-G, \--config
+:   Displays the current config and exits.
+
+-L, \--list
+:   Displays the list report categories and exits.
+
+-C *IP*, \--check *IP*
+:   Performs a check request for the given IP address. A valid IPv4 or IPv6 address is required.
+
+-R *IP*, \--report *IP*
+:   Performs a report request for the given IP address. A valid IPv4 or IPv6 address is required.
+
+-V *FILE*, \--bulk-report FILE
+:   Performs a bulk-report request sending a csv file. A valid file name or full path is required.
+
+-E *IP*, \--clear *IP*
+:   Remove own reports for the given IP address. A valid IPv4 or IPv6 address is required.
+
+-K *NETWORK*, \--checkblock *NETWORK*
+:   Performs a check-block request for the given network. A valid subnet (v4 or v6) denoted with 
+    CIDR notation is required.
+
+-B, \--blacklist
+:   Performs a blacklist request: get a list of reported IPs.
+
+\---version
+:   Prints the current version.
+
+
+# OPTIONS
+
+-d *DAYS*, \--days *DAYS*
+:   For a check or check-block request, defines the maxAgeDays. Min is 1, max is 365, default is 30.
+
+-c *CATEGORIES*, \--categories *CATEGORIES*
+:   For a report request, defines the report category(ies). Categories must be separate by a comma. 
+    Some catgeries cannot be used alone. A category can be represented by its shortname or by its id. 
+    Use abuseipdb -L to print the categories list.
+
+-m *MESSAGE*, \--message *MESSAGE*
+:   For a report request, defines the message to send with report. Message is required for all report 
+    requests.
+
+-l *LIMIT*, \--limit *LIMIT*
+:   For a blacklist request, defines the limit (default is 1000). For a check request with verbose flag, 
+    sets the max number of last reports displayed (default is 10). For a check-block request, sets the 
+    max number of IPs displayed (default is 0 mean no limit).
+
+-o *FORMAT*, \--output *FORMAT*
+:   Defines the output format for API requests. Default is a colorized report, possible formats are 
+    json or plaintext. Plaintext option prints partial response (blacklist: IPs list, check or report: 
+    confidence score only, check-block: reported IP list with confidence score, bulk-report: 
+    number of saved reports, clear: number of deleted reports).
+
+-s *SCORE*, \--score *SCORE*
+:   For a blacklist request, sets the confidence score minimum. The confidence minimum must be between 
+    25 and 100. This parameter is subscriber feature (not honored otherwise, allways 100).
+
+-t *TIMEOUT*, \--timeout *TIMEOUT*
+:   Define the timeout in API request and overwrite the value defined in conf.ini or local.ini.
+    Timeout is expressed in milliseconds.
+
+-v, \--verbose
+:   For a check request, display additional fields like the x last reports. Max number of last reports 
+    is defined in config. This increases request time and response size.
+
+# BUGS
+
+Submit bug reports online at: <https://github.com/kristuff/abuseipdb-cli/issues>
+
+# SEE ALSO
+
+Source code at: <https://github.com/kristuff/abuseipdb-cli>
+
+Full documentation at: <https://kristuff.fr/projects/abuseipdbcli/doc>
+

--- a/src/AbuseIPDBClient.php
+++ b/src/AbuseIPDBClient.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
@@ -176,6 +176,10 @@ class AbuseIPDBClient extends AbstractClient
         Console::log('       For a blacklist request, sets the confidence score minimum. The confidence minimum ', 'lightgray');
         Console::log('       must be between 25 and 100. This parameter is subscriber feature (not honored otherwise, allways 100).', 'lightgray');
         Console::log();    
+        Console::log(Console::text('   -t, --timeout ', 'white'). Console::text('TIMEOUT', 'yellow', 'underline')); 
+        Console::log('       Define the timeout in API request and overwrite the value defined in conf.ini or local.ini.', 'lightgray');
+        Console::log('       Timeout is expressed in milliseconds.', 'lightgray');
+        Console::log();    
         Console::log(Console::text('   -v, --verbose ', 'white')); 
         Console::log('       For a check request, display additional fields like the x last reports. This increases ', 'lightgray');
         Console::log(Console::text('       request time and response size. Max number of last reports displayed can be changed with the ', 'lightgray'));
@@ -202,6 +206,7 @@ class AbuseIPDBClient extends AbstractClient
         self::printTitle(Console::text('  ► Current configuration ', 'darkgray'));
         
         Console::log(Console::text('  api_key:[', 'white') . Console::text($conf['apiKey'], 'green') . Console::text(']', 'white'));
+        Console::log(Console::text('  timeout:[', 'white') . Console::text($conf['timeout'], 'green') . Console::text(']', 'white'));
         Console::log(Console::text('  self_ips:', 'white'));
         
         foreach ($conf['selfIps'] as $ip) {

--- a/src/BulkReportTrait.php
+++ b/src/BulkReportTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/CheckBlockTrait.php
+++ b/src/CheckBlockTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/CheckTrait.php
+++ b/src/CheckTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/ShellErrorHandler.php
+++ b/src/ShellErrorHandler.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;

--- a/src/ShellUtils.php
+++ b/src/ShellUtils.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
@@ -147,7 +147,6 @@ abstract class ShellUtils
         Console::log();
         Console::log(Console::text('  Kristuff/AbuseIPDB Client version: ', 'darkgray') . Console::text(AbuseIPDBClient::VERSION, 'lightgray'));
         Console::log(Console::text('  Kristuff/AbuseIPDB Core version:   ', 'darkgray') . Console::text(ApiHandler::VERSION, 'lightgray')); 
-        Console::log(Console::text('  --------------------------------------------------', 'darkgray'));    
         Console::log(Console::text('  Released under the MIT licence', 'darkgray'));
         Console::log(Console::text('  Made with ', 'darkgray') . Console::text('♥', 'red') . Console::text(' in France', 'darkgray'));
         Console::log(
@@ -155,7 +154,7 @@ abstract class ShellUtils
             Console::text('https://github.com/kristuff', 'darkgray', 'underlined').
             Console::text(')', 'darkgray')
         );
-        Console::log(Console::text('  --------------------------------------------------', 'darkgray'));    
+        //Console::log(Console::text('  --------------------------------------------------', 'darkgray'));    
         Console::log();
     }
 

--- a/src/UtilsTrait.php
+++ b/src/UtilsTrait.php
@@ -13,7 +13,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.16
+ * @version    0.9.17
  * @copyright  2020-2021 Kristuff
  */
 namespace Kristuff\AbuseIPDB;


### PR DESCRIPTION
**Changes**
- **New** **timeout** option for cURL requests.
A default value can be defined in configuration file (`timout` key in `[common]` section), and can be overwritten in command line (`-t` | `--timeout` options available in all API request commands). Timeout is expressed in **milliseconds**.
- **New** man page and changelog now available in `.deb` package
- Formatting