### PR TITLE
v0.9.18

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 kristuff
+Copyright (c) 2020-2022 kristuff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 - Clear IP address request (remove your own reports) **✓**
 - Auto cleaning report comments from sensitive data (email, custom ip/domain names list)  **✓** 
 - Output: colored reports, JSON or plaintext **✓** 
+- Define timeout for cURL internal requests (in config or from command line) **✓**
 - Easy Fail2ban integration **✓** 
 
 Requirements
@@ -64,7 +65,7 @@ License
 
 The MIT License (MIT)
 
-Copyright (c) 2020-2021 Kristuff
+Copyright (c) 2020-2022 Kristuff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/abuseipdb
+++ b/bin/abuseipdb
@@ -14,8 +14,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 
 use Kristuff\AbuseIPDB\AbuseIPDBClient;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.1",
         "kristuff/mishell": "^1.5-stable",
-        "kristuff/abuseipdb": "^0.9.14-stable"
+        "kristuff/abuseipdb": "^1.0-stable"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b7c747fd2936535a7360589ba62f1b7f",
+    "content-hash": "34026614b73f273a38bf32e4512291e8",
     "packages": [
         {
             "name": "kristuff/abuseipdb",
-            "version": "v0.9.14",
+            "version": "v1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kristuff/abuseipdb.git",
-                "reference": "d1d9cf9ad0fcac083e4c24aa009850e43e83cf24"
+                "reference": "5639f1813a7be889c9028f722e9fe252bac34df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kristuff/abuseipdb/zipball/d1d9cf9ad0fcac083e4c24aa009850e43e83cf24",
-                "reference": "d1d9cf9ad0fcac083e4c24aa009850e43e83cf24",
+                "url": "https://api.github.com/repos/kristuff/abuseipdb/zipball/5639f1813a7be889c9028f722e9fe252bac34df1",
+                "reference": "5639f1813a7be889c9028f722e9fe252bac34df1",
                 "shasum": ""
             },
             "require": {
@@ -48,9 +48,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kristuff/abuseipdb/issues",
-                "source": "https://github.com/kristuff/abuseipdb/tree/v0.9.14"
+                "source": "https://github.com/kristuff/abuseipdb/tree/v1.0"
             },
-            "time": "2021-12-06T20:40:39+00:00"
+            "time": "2022-01-26T21:24:24+00:00"
         },
         {
             "name": "kristuff/mishell",

--- a/config/conf.ini
+++ b/config/conf.ini
@@ -4,7 +4,7 @@
 ;  \__,_|_.__/\_,_/__/\___|___|_| |___/|___/
 ;  
 ;  Kristuff\AbuseIPDB-client configuration file.
-;  v0.9.17 | (c) Kristuff <kristuff@kristuff.fr>
+;  v0.9.18 | (c) Kristuff <kristuff@kristuff.fr>
 
 ; -----------------------------------------------------------
 ; WARNING:  In most of the cases you should not modify this                    
@@ -27,13 +27,16 @@ api_key=
 ;   The maximum number of milliseconds to allow cURL functions to execute. If libcurl is 
 ;   built to use the standard system name resolver, that portion of the connect will still 
 ;   use full-second resolution for timeouts with a minimum timeout allowed of one second. 
-;   Default is 0 (no timeout) 
+;   Default is 0 (no timeout)
+;
+;   Example for 5 seconds timeout: 
+;      timeout=5000
 timeout=0
 
 [report]
 ; self_ips: 
-;   Represents the ips or domain list to exclude from report messages (email address are already removed)
-;   List MUST be comma separated and MAY comtain spaces. Order does matter for subdomains.
+;   Represents the ips or domain list to exclude from report messages (email addresses are already removed)
+;   List MUST be comma separated and MAY contain spaces. Order does matter for subdomains.
 ;
 ;   Example: 
 ;      self_ips= "xx9999.ip-256-256-256.xx ,256.256.256.256, subdomain.example.com,example.com, example"

--- a/create_package.sh
+++ b/create_package.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# make sure we are in current directory as the script may be run from another location
+# to use relative path 
+#cd `dirname $0`
+
 # our dist directory
 mkdir -p dist
 
@@ -10,6 +14,7 @@ mkdir -p debian/usr/lib/abuseipdb-client
 mkdir -p debian/usr/share/doc/abuseipdb-client
 mkdir -p debian/usr/share/man/man1
 mkdir -p debian/etc/abuseipdb-client
+#mkdir -p debian/etc/fail2ban
 
 # populate the debian directory
 cp deb/control           debian/DEBIAN
@@ -20,10 +25,19 @@ cp config/conf.ini       debian/etc/abuseipdb-client
 cp deb/copyright         debian/usr/share/doc/abuseipdb-client
 cp deb/changelog         debian/usr/share/doc/abuseipdb-client/changelog.Debian
 gzip -9 -n               debian/usr/share/doc/abuseipdb-client/changelog.Debian
+# Fix Error debian-changelog-file-missing-or-wrong-name
+# but add a warning instead duplicate-changelog-files
+# see https://www.debian.org/doc/debian-policy/ch-docs.html#s-changelogs
+cp deb/changelog         debian/usr/share/doc/abuseipdb-client/changelog
+gzip -9 -n               debian/usr/share/doc/abuseipdb-client/changelog
+
 cp LICENSE               debian/usr/lib/abuseipdb-client
 cp -R bin                debian/usr/lib/abuseipdb-client
 cp -R src                debian/usr/lib/abuseipdb-client
 cp -R vendor             debian/usr/lib/abuseipdb-client
+cp -R fail2ban           debian/usr/lib/abuseipdb-client
+#cp -R fail2ban           debian/etc/fail2ban
+
 
 # convert and deploy man page
 /usr/bin/pandoc --standalone --to man deb/man.md -o debian/usr/share/man/man1/abuseipdb.1
@@ -34,7 +48,8 @@ cp composer.json        debian/usr/lib/abuseipdb-client
 cp composer.lock        debian/usr/lib/abuseipdb-client
 
 # adjust ownerships
-chown -R root:root      debian
+# chown -R root:root      debian
+# unused since --root-owner-group option in dpkg-deb
 find debian -type d -exec chmod 0755 {} \;  #set directory attributes
 find debian -type f -exec chmod 0644 {} \;  #set data file attributes
 find debian/usr/lib/abuseipdb-client/bin -type f -exec chmod 0755 {} \;  #set executable attributes
@@ -44,4 +59,5 @@ chmod 755 debian/DEBIAN/postinst
 chmod 755 debian/DEBIAN/prerm
 
 # finally build the package
-dpkg-deb --build debian dist
+dpkg-deb --root-owner-group --build debian . 
+#dist

--- a/deb/changelog
+++ b/deb/changelog
@@ -1,39 +1,49 @@
-abuseipdb-client (0.9.17+deb11u1) unstable; urgency=low
+abuseipdb-client (0.9.18) unstable; urgency=medium
 
-  * Improve/fix package
-     Fix typos in man page, files permissions, scripts error reporting
-     php-cli is now the dependency (instead of php)
-     conf.ini under /etc now marqued as conffile
+  * Change: minor change in chaeck report when total reports is 0
+    and lastReportedAt field is not null (could happen when deleting
+    report)
+  * Include Fail2ban action file (abuseipdb.local) in package
+  * Update dependency
 
- -- kristuff <kristuff@kristuff.fr>  Thu, 09 Dec 2021 19:00:00 +0100
+ -- kristuff <kristuff@kristuff.fr>  Wed, 26 Jan 2022 19:00:00 +0200
 
-abuseipdb-client (0.9.17) unstable; urgency=low
+abuseipdb-client (0.9.17+deb11u1) unstable; urgency=medium
+
+  * Improve/fix package:
+    Fix typos in man page, files permissions, scripts error reporting
+    php-cli is now the dependency (instead of php)
+    conf.ini under /etc now marked as conffile
+
+ -- kristuff <kristuff@kristuff.fr>  Thu, 09 Dec 2021 19:00:00 +0200
+
+abuseipdb-client (0.9.17) unstable; urgency=medium
 
   * New feature: timeout for all cURL request can be defined in conf.ini
     or from command line using the -t, --timeout option. Timeout is expressed
     in milliseconds.
   * A man page is now available  
 
- -- kristuff <kristuff@kristuff.fr>  Tue, 07 Dec 2021 19:00:00 +0100
+ -- kristuff <kristuff@kristuff.fr>  Tue, 07 Dec 2021 19:00:00 +0200
 
-abuseipdb-client (0.9.16) unstable; urgency=low
+abuseipdb-client (0.9.16) unstable; urgency=medium
 
   * Fix php doc, typo, formatting in source code
   * Include composer.json and composer.lock in .deb package
 
- -- kristuff <kristuff@kristuff.fr>  Sun, 28 Nov 2021 19:00:00 +0100
+ -- kristuff <kristuff@kristuff.fr>  Sun, 28 Nov 2021 19:00:00 +0200
 
-abuseipdb-client (0.9.15) unstable; urgency=low
+abuseipdb-client (0.9.15) unstable; urgency=medium
 
   * Break change Configuration is now in INI format and located in a conf.ini file 
     (with possible override in a local.ini file) instead of json files. 
   * The save-key command has been removed.
   * When installing the .deb package, config is now located in /etc/abuseipdb-client/
 
- -- kristuff <kristuff@kristuff.fr>  Tue, 23 Nov 2021 19:00:00 +0100
+ -- kristuff <kristuff@kristuff.fr>  Tue, 23 Nov 2021 19:00:00 +0200
 
-abuseipdb-client (0.9.14) unstable; urgency=low
+abuseipdb-client (0.9.14) unstable; urgency=medium
 
   * Initial release
 
- -- kristuff <kristuff@kristuff.fr>  Wed, 10 Nov 2021 19:00:00 +0100
+ -- kristuff <kristuff@kristuff.fr>  Wed, 10 Nov 2021 19:00:00 +0200

--- a/deb/control
+++ b/deb/control
@@ -1,5 +1,5 @@
 Package: abuseipdb-client
-Version: 0.9.17+deb11u1
+Version: 0.9.18
 Maintainer: kristuff <kristuff@kristuff.fr>
 Architecture: all
 Depends: php-cli, php-curl

--- a/deb/copyright
+++ b/deb/copyright
@@ -3,7 +3,7 @@ Upstream-Name: AbuseIPDB-client
 Upstream-Contact: kristuff <kristuff@kristuff.fr>
 
 Files: *
-Copyright: 2020-2021 Kristuff <kristuff@kristuff.fr>
+Copyright: 2020-2022 Kristuff <kristuff@kristuff.fr>
 License: MIT License 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/deb/man.md
+++ b/deb/man.md
@@ -33,7 +33,7 @@ or IPv6.
 -R *IP*, \--report *IP*
 :   Performs a report request for the given IP address. A valid IPv4 or IPv6 address is required.
 
--V *FILE*, \--bulk-report FILE
+-V *FILE*, \--bulk-report *FILE*
 :   Performs a bulk-report request sending a csv file. A valid file name or full path is required.
 
 -E *IP*, \--clear *IP*

--- a/fail2ban/action.d/abuseipdb.local
+++ b/fail2ban/action.d/abuseipdb.local
@@ -1,0 +1,5 @@
+# fail2ban configuration file for Kristuff/abuseipdb-cli
+
+[Definition]
+# Uncomment the following line to change the actionban to use our custom script
+#actionban = /usr/bin/abuseipdb -R "<ip>" -c "<abuseipdb_category>" -m "<abuseipdb_comment>" > /dev/null

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 
@@ -41,7 +41,7 @@ abstract class AbstractClient extends ShellErrorHandler
     /**
      * @var string
      */
-    const VERSION = 'v0.9.17'; 
+    const VERSION = 'v0.9.18'; 
 
     /**
      * @var QuietApiHandler

--- a/src/AbuseIPDBClient.php
+++ b/src/AbuseIPDBClient.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 

--- a/src/BulkReportTrait.php
+++ b/src/BulkReportTrait.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 

--- a/src/CheckBlockTrait.php
+++ b/src/CheckBlockTrait.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 

--- a/src/CheckTrait.php
+++ b/src/CheckTrait.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 
@@ -107,8 +107,17 @@ trait CheckTrait
 
         } else {
             // no reports
-            $day = $maxAge > 1 ? 'in last '. $maxAge . ' days': ' today';
-            Console::log( Console::text('   ✓', 'green') . Console::text(' Not reported ' . $day));
+            $period = $maxAge > 1 ? 'in last '. $maxAge . ' days': ' today';
+            if (empty($response->data->lastReportedAt)){
+                Console::log( Console::text('   ✓', 'green') . Console::text(' Not reported ' . $period));
+            
+            } else {
+                // in some case, we have no reports but lastReportedAt in not empty (when deleting reports for example)
+                // maybe a bug or cache in api 
+                // In this case Set total 0 and let print lastReportedAt
+                $line  = self::printResult(Console::pad('   Total reports:', 23), $nbReport, $color, '', false);
+                Console::log($line);
+            }
         }
         
         if (!empty($response->data->lastReportedAt)){

--- a/src/ShellErrorHandler.php
+++ b/src/ShellErrorHandler.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 

--- a/src/ShellUtils.php
+++ b/src/ShellUtils.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 
@@ -150,7 +150,7 @@ abstract class ShellUtils
         Console::log(Console::text('  Released under the MIT licence', 'darkgray'));
         Console::log(Console::text('  Made with ', 'darkgray') . Console::text('♥', 'red') . Console::text(' in France', 'darkgray'));
         Console::log(
-            Console::text('  © 2020-2021 Kristuff (', 'darkgray').
+            Console::text('  © 2020-2022 Kristuff (', 'darkgray').
             Console::text('https://github.com/kristuff', 'darkgray', 'underlined').
             Console::text(')', 'darkgray')
         );
@@ -172,7 +172,7 @@ abstract class ShellUtils
             Console::log();    
             Console::log( Console::text(' Kristuff/AbuseIPDB-client ', 'darkgray') . Console::text(' ' . AbuseIPDBClient::VERSION . ' ', 'white', 'blue')); 
             Console::log(Console::text(' Made with ', 'darkgray') . Console::text('♥', 'red') . Console::text(' in France', 'darkgray')); 
-            Console::log(Console::text(' © 2020-2021 Kristuff (', 'darkgray').
+            Console::log(Console::text(' © 2020-2022 Kristuff (', 'darkgray').
                 Console::text('https://github.com/kristuff', 'darkgray', 'underlined').
                 Console::text(')', 'darkgray')
             );
@@ -204,7 +204,7 @@ abstract class ShellUtils
                 Console::text(AbuseIPDBClient::VERSION, 'lightgray') . 
                 Console::text(' | Made with ', 'darkgray') . 
                 Console::text('♥', 'red') .
-                Console::text(' in France | © 2020-2021 Kristuff (https://github.com/kristuff)', 'darkgray')
+                Console::text(' in France | © 2020-2022 Kristuff (https://github.com/kristuff)', 'darkgray')
             ); 
             Console::log(); 
         }   

--- a/src/UtilsTrait.php
+++ b/src/UtilsTrait.php
@@ -13,8 +13,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @version    0.9.17
- * @copyright  2020-2021 Kristuff
+ * @version    0.9.18
+ * @copyright  2020-2022 Kristuff
  */
 namespace Kristuff\AbuseIPDB;
 


### PR DESCRIPTION
**Changes**
- **Fixed**: remove check mark (✓) in *check* reports in case IP has no reports but lastReportedAt in not empty
- **Added**: abuseipdb.local under fail2ban directory can be used as template to overwite the default .conf file.
- Update dependency version